### PR TITLE
Fix import statements under pviewmod (pipedviewer module) for Python3.6

### DIFF
--- a/pviewmod/__init__.py
+++ b/pviewmod/__init__.py
@@ -35,14 +35,14 @@ class PipedViewer(object):
         (self.__rspdrecvpipe, self.__rspdsendpipe) = Pipe(False)
         if viewertype == "PipedViewerPQ":
             try:
-                from pipedviewerpq import PipedViewerPQProcess
+                from pipedviewer.pipedviewerpq import PipedViewerPQProcess
             except ImportError:
                 raise TypeError("The PQ viewers requires PyQt5 or PyQt4")
             self.__vprocess = PipedViewerPQProcess(self.__cmndrecvpipe,
                                                    self.__rspdsendpipe)
         elif viewertype == "PipedImagerPQ":
             try:
-                from pipedimagerpq import PipedImagerPQProcess
+                from pipedviewer.pipedimagerpq import PipedImagerPQProcess
             except ImportError:
                 raise TypeError("The PQ viewers requires PyQt5 or PyQt4")
             self.__vprocess = PipedImagerPQProcess(self.__cmndrecvpipe,

--- a/pviewmod/pipedimagerpq.py
+++ b/pviewmod/pipedimagerpq.py
@@ -42,8 +42,8 @@ except ImportError:
 
 from multiprocessing import Pipe, Process
 
-from cmndhelperpq import CmndHelperPQ
-from scaledialogpq import ScaleDialogPQ
+from pipedviewer.cmndhelperpq import CmndHelperPQ
+from pipedviewer.scaledialogpq import ScaleDialogPQ
 
 
 

--- a/pviewmod/pipedviewerpq.py
+++ b/pviewmod/pipedviewerpq.py
@@ -49,8 +49,8 @@ except ImportError:
 
 from multiprocessing import Pipe, Process
 
-from cmndhelperpq import CmndHelperPQ
-from scaledialogpq import ScaleDialogPQ
+from pipedviewer.cmndhelperpq import CmndHelperPQ
+from pipedviewer.scaledialogpq import ScaleDialogPQ
 
 
 class PipedViewerPQ(QMainWindow):


### PR DESCRIPTION
With this the viewers under PyQt5 on Mac Sierra are sort-of working.  The test __main__ in each will start, show the window, do some drawing.  But at some point in the commands fed to them, they crash.  Need to try on some other system with Python 3.x (I know >= 3.3 from functions used, but only tested on 3.6 so far) and either PyQt4 or PyQt5.