### PR TITLE
updating tutorial/ demo scripts so they don't depend on urls

### DIFF
--- a/bench/v7jnls/bn764_bug_fixes.jnl
+++ b/bench/v7jnls/bn764_bug_fixes.jnl
@@ -6,3 +6,6 @@ GO err763_din.jnl
 
 GO bn_reset
 GO err763_plot_vs_axlab.jnl  
+
+GO bn_reset
+GO err763_palette_bug.jnl 

--- a/bench/v7jnls/err763_palette_bug.jnl
+++ b/bench/v7jnls/err763_palette_bug.jnl
@@ -1,0 +1,109 @@
+! err763_palette_bug.jnl
+! See PyFerret issue 98
+! Ansley Manke 11/11/2021
+!
+!  Set a color palette with /PALETTE in combination with /SET. The default palette
+!  not restored before making the next plot.
+
+! Define an example 2D variable to plot
+let var = i[i=1:5] + j[j=1:5]
+
+! This is correct:
+! After a /palette setting on one plot, the next one uses the default palette.
+! The script saves one image to compare, and goes on to test all plot types.
+
+set view ul
+shade/palette=purple_red var
+
+set view ur
+shade/title="Next plot reverts to current default palette" var
+
+! But if /SET used, the next plot used wrong palette.
+
+set view ll
+shade/set/palette=blue_orange/title="blue_orange palette with /SET" var
+ppl shakey,1,1,,0,-2 
+ppl shade
+
+set view lr
+shade/title="Next plot should revert to current default palette" var
+frame/file=err763_palette_bug.png
+
+! Similar tests using other plot commands that use color palettes.
+can view
+
+set view ul
+use simple_traj_dsg
+ribbon/set/palette=yellow_green_blue/thick=3/title="Ribbon plot with /SET/PAL=yellow_green_blue" sst
+ppl shakey,1,1,,0,-2 
+ppl ribbon
+
+set view ur
+shade/title="Next plot should revert to current default palette" var
+
+set view ll
+LET xtriangle = {0,.5,1}
+LET ytriangle = {0,1,0}
+LET xpts = 10*RANDU(j[j=1:20]+0)	! random X coordinates
+LET ypts = 10*RANDU(j[j=1:20]+1)	! random Y coordinates
+LET values = 10* j[j=1:20]		! value at each (x,y) point
+POLYGON/set/palette=cmocean_solar/title="cmocean_solar palette with /SET" xpts+xtriangle, ypts+ytriangle, values
+ppl shakey,1,1,,0,-2 
+ppl polygon
+
+
+set view lr
+shade/title="Next plot should revert to current default palette" var
+
+
+!!!!!!!!!!!!!!!!!!!!!  FILL plots
+palette default
+
+can view
+
+
+
+set view ul
+fill/palette=rainbow/title="/PALETTE=rainbow" var
+
+set view ur
+fill/title="Next plot should revert to current default palette" var
+
+! With /SET on first plot; second was wrong.
+set view ll
+fill/set/palette=cmocean_speed/title="cmocean_speed palette with /SET" var
+ppl shakey,1,1,,0,-2 
+ppl fill
+
+set view lr
+fill/title="Next plot should revert to current default palette" var
+
+
+! Now set an alternative palette for the remainder of the session (or until reset)
+can view
+
+PALETTE magma
+
+set view ul
+fill/palette=cmocean_phase/title="/PALETTE=cmocean_phase" var
+
+set view ur
+fill/title="After PALETTE magma setting, next plot uses current default palette" var
+
+! With /SET on first plot; second was wrong.
+set view ll
+fill/set/palette=cmocean_balance/title="cmocean_balance palette with /SET" var
+ppl shakey,1,1,,0,-2 
+ppl fill
+
+set view lr
+fill/title="Next plot should revert to current default palette" var
+
+cancel view
+
+palette    ! PALETTE with no argument, use current default palette setting (magma)
+
+fill/title="current default palette" var
+
+! Restore PyFerret's usual default palette
+PALETTE default

--- a/bench/v7jnls/err763_plot_vs_axlab.jnl
+++ b/bench/v7jnls/err763_plot_vs_axlab.jnl
@@ -32,3 +32,4 @@ plot/vs/line/thick/hlim=50:160/vlim=-90:0/noax xs, ys
 plot/vs/over/nolab/line/thick/color=blue/axes xs, ys-20
 
 frame/file=plot_vs_over_axes.png
+cancel mode grat

--- a/fer/common/xplot_state.cmn
+++ b/fer/common/xplot_state.cmn
@@ -20,6 +20,8 @@
 *                  /HALFSPAC adds a half space between the degree sign and E/W or N/S
 * V73+ 1/18 *acm* Changes for Issue 1009; precsision in time info sent to pplus for 2D plots
 *                 scaling for axis coords and box edges, saved_bb_date needed for polygons
+* V764 11/21 *acm* For PyFerret issue 98, if PLOT/SET/PALETTE, save info so the state can
+*                 be restored after the plot is completed
 
 	INTEGER		max_windows,
      .			max_viewport,
@@ -38,7 +40,8 @@
      .			h_logaxis, 
      .			v_logaxis,
      .                  no_plot_yet,
-     .                  changed_key
+     .                  changed_key,
+     .                  set_palette
 
 	INTEGER		vp_num,
      .			vp_seg0,
@@ -141,6 +144,7 @@
      .			v_logaxis,
      .                  no_plot_yet,
      .                  changed_key,
+     .                  set_palette,
      .			saved_dt_min,
      .			saved_t1_date,
      .			saved_bb_date,

--- a/fer/plt/disp_data_set_up.F
+++ b/fer/plt/disp_data_set_up.F
@@ -68,6 +68,8 @@
 * V76  1/20 *acm* working with Point-type dsg data
 * V760 *acm* 3/20 Flag for case when constraints result in no features
 * v763 *acm* 9/20 Plots of id-variables in trajectory-profile, timeseries-profile data
+* V764 11/21 *acm* For PyFerret issue 98, if PLOT/SET/PALETTE, save info so the color 
+*                 palette can be restored after the plot is completed. New flag set_palette.
 
         IMPLICIT NONE
 	include 'tmap_dims.parm'
@@ -83,6 +85,7 @@
 	include 'xdset_info.cmn_text'
 	include 'xtm_grid.cmn_text'
 	include 'xtext_info.cmn'
+	include 'xplot_state.cmn'
 
 	
 * calling argument declarations:
@@ -91,7 +94,7 @@
 * internal variable declarations:
 	LOGICAL TM_ITSA_DSG_RAGGED, TM_ITSA_DSG, 
      .		plot_vs, typerr, its_dsg, its_cmpnd, its_traj, 
-     .		dsg_as_traj, dsg_as_time
+     .		dsg_as_traj, dsg_as_time, spect, setup
 	INTEGER	MR_DIM_LEN, CX_DIM_LEN, CGRID_SIZE, TM_DSG_NFEATURES,
      .		TM_DSG_DSET_FROM_GRID, DSG_WHATS_IT,
      .		idim, ndim, dim(nferdims), mr1, cx, ivar,
@@ -121,7 +124,6 @@
 	IF ( status .NE. ferr_ok ) GOTO 5100
 
 	numv = num_uvars_in_cmnd
-
 
 * ragged DSG data?
 * For a trajectory dataset, the variable may be on the instance axis 
@@ -185,6 +187,29 @@
 	      ENDIF
 	   ENDIF	   
 	ENDIF
+	
+* if the color palette was changed by a previous plot using /PALETTE= and /SET, reset it.
+
+	IF (set_palette ) CALL PPL_SHASET( 'SPECTRUM' )
+	set_palette = .FALSE.
+
+* If this command is a color plot using /PALETTE= and /SET, then set the flag set_palette
+* Don't worry about checking for valid settings here; any errors will be caught later.
+
+	spect = .FALSE.
+	setup = .FALSE.
+	IF (cmnd_num .EQ. cmnd_plot) THEN
+	   spect = qual_given(slash_plot_spectrum) .GT.0 
+	   setup = qual_given(slash_plot_set_up) .GT. 0
+
+	ELSEIF (cmnd_num .EQ. cmnd_contour .OR.  cmnd_num.EQ.cmnd_shade .OR. 
+     .                cmnd_num.EQ.cmnd_polygon) THEN
+	   spect = qual_given(slash_cont_spectrum) .GT.0 
+	   setup = qual_given(slash_cont_set_up) .GT.0 
+
+	ENDIF
+
+	IF ( spect .AND. setup) set_palette = .TRUE.
 
 * compute working storage
 	IF (cmnd_num .EQ. cmnd_polygon) THEN

--- a/fer/plt/disp_reset.F
+++ b/fer/plt/disp_reset.F
@@ -57,6 +57,8 @@
 * V697  *acm*  1/16 Ticket 2344: if there was a time-plot underlay, use the underlay's 
 *                   time scaling for time overlay plots. TAXUND restores the default.
 * V7.4+ *acm*  8/18 DSG-enabled Ferret: colorkey labels may be strings from the IDs
+* V764 11/21 *acm* For PyFerret issue 98, if PLOT/SET/PALETTE, save info so the color 
+*                 palette can be restored after the plot is completed. Initialize the flag here.
 
         IMPLICIT NONE
 	include 'tmap_dims.parm'
@@ -124,6 +126,7 @@ c	CALL PPLCMD ( from, line, 0, 'TXNMTC 0', 1, 1 )
 * set up the default spectrum
         CALL PPL_SHASET( 'RESET' )
         CALL PPL_SHASET( 'SPECTRUM=default' )
+	set_palette = .FALSE.
 
 * Set default (initial) number of color levels
 

--- a/fer/xeq/xeq_pplus.F
+++ b/fer/xeq/xeq_pplus.F
@@ -54,6 +54,8 @@
 * V6.86 *acm* 1/14 In above fix, let there be spaces before the file spec.
 * V7.4 *acm* 1/18 for issue 1854 if mem pointers for curvi coord data have
 *                 been temporarily reset, restore to prev values
+* V764 11/21 *acm* For PyFerret issue 98, if PLOT/SET/PALETTE, save info so the color 
+*                 palette can be restored after the plot is completed. Here restore the palette.
  
         IMPLICIT NONE
 	include 'tmap_dims.parm'
@@ -72,7 +74,7 @@
 	include 'gkscm1_inc.decl'
 	include 'GKSCM1.INC'	 ! wsid
         INCLUDE 'fgrdel.cmn'     ! windowdpix, windowdpiy
-
+	INCLUDE   'parampl5_dat.decl'
 
 * local variable declarations:
 	LOGICAL	ver_out, jnl_out
@@ -196,13 +198,19 @@
      .      ( INDEX(vbuff,'FILL')    .GT. 0 ) .OR.
      .      ( INDEX(vbuff,'PLOT')    .GT. 0 ) .OR.
      .      ( INDEX(vbuff,'POLY')    .GT. 0 ) .OR.
-     .      ( INDEX(vbuff,'WIRE')    .GT. 0 )    ) THEN 
+     .      ( INDEX(vbuff,'WIRE')    .GT. 0 )  .OR.
+     .      ( INDEX(vbuff,'RIBB')    .GT. 0 )   ) THEN 
 	   IF (iaxset .EQ. 1) THEN   ! If /AXES was used on prev. plot call, reset defaults
 	      CALL PPL_AXES_RESTORE
 	      CALL PPLCMD ( from, line, 0, 'AXSET,1,1,1,1', 1, 1 )
 	      CALL PPLCMD ( from, line, 0, 'AXLABP -1,-1', 1, 1)
 	      iaxset = 0
 	   ENDIF
+
+* Also restore color palette
+
+           IF ( set_palette ) CALL PPL_SHASET( 'SPECTRUM' )
+
 	ENDIF
 
 	IF (( INDEX(vbuff,'SHADE')   .GT. 0 ) .OR.
@@ -211,7 +219,10 @@
      .      ( INDEX(vbuff,'VECTOR')  .GT. 0 ) .OR.
      .      ( INDEX(vbuff,'POLY')    .GT. 0 ) .OR.
      .      ( INDEX(vbuff,'WIRE')    .GT. 0 )    ) THEN 
+
 	   CALL RESTORE_CURVI   
+
+
 	ENDIF     
 
 * check to see if ylen or yorg has been changed

--- a/fmt/src/cd_dsg_scan_vars.F
+++ b/fmt/src/cd_dsg_scan_vars.F
@@ -67,7 +67,9 @@
 * v7.6 *acm* 5/20 Issue 1876: can read string-typed data, write as char.
 * V7.6 *acm* 6/20 Issue 1980: When possible open invalid DSG datasets anyway with NOTES.
 * V7.61 *acm* 7/20 Adding logic for TrajectoryProfile and TimeseriesProfile datasets.
-* V7.61 *acm* 7/80 FOR NOW, initialize TrajectoryProfile and TimeseriesProfile as profile.
+* V7.61 *acm* 7/20 FOR NOW, initialize TrajectoryProfile and TimeseriesProfile as profile.
+* V7.64 *acm* 10/21 Fix bug: point-type datasets incorrectly required a Z coordinate variable
+*                                       but as for trajectory data, relax this requirement.
 
 * argument definitions:
 *       dset    - pointer to TMAP data set
@@ -232,13 +234,13 @@ c	ENDIF
 * When these are found, use units to nail down the direction.
 *
 * Check: need lon, lat, time for all feature types. Profiles need depth/height.
-* Can get away without z direction for trajectories or timeseries.
+* Can get away without z direction for trajectories or timeseries or point data
 
 	DO idim = 1, 4
 	   ax_att_var(idim) = int4_init
 	   ax_att_provisional(idim) = int4_init
 	   need_coord(idim) = .TRUE.
-	   IF ((orient.EQ.x_dim .OR. orient.EQ.t_dim) .AND. 
+	   IF ((orient.EQ.x_dim .OR. orient.EQ.t_dim.OR. orient.EQ.e_dim) .AND. 
      .          idim.EQ.z_dim ) need_coord(z_dim) = .FALSE.
 	ENDDO
 
@@ -734,7 +736,6 @@ c     .               vname(:vlen) )
 * axis of length npoints
 
 	         IF (dsg_feature_type(dset) .EQ. pfeatureType_Point) THEN
-
 
 * Don't need to allocate memory for the synthesized Obs axis
 * just use the basic-axis call in CD_DSG_SETUP_PTDATA (?)

--- a/jnls/contrib/plot_vectors.jnl
+++ b/jnls/contrib/plot_vectors.jnl
@@ -2,7 +2,7 @@
 
 !**************************************************************
 ! Description: plot over vectors 
-!http://ferret.wrc.noaa.gov/Ferret/Mail_Archives/fu_2000/msg00513.html
+! https://www.pmel.noaa.gov/maillists/tmap/ferret_users/fu_2000/msg00513.html
 ! Usage: go plot_vectors u v lon lat [skip] [fill]
 !                  
 !
@@ -55,7 +55,7 @@
 say " "
 say "This script is superseded by the script vect_cylin.jnl or vect_cylin_over.jnl"
 say "which is available in the FAST scripts package at "
-say "http://dods.ipsl.jussieu.fr/fast/fiches/f00/f00.html"
+say "https://github.com/PBrockmann/fast"
 say " "
 say "Or see the scripts poly_vectors.jnl and mp_poly_vectors.jnl for vectors"
 say "drawn as filled polygons"

--- a/jnls/examples/dods_demo.jnl
+++ b/jnls/examples/dods_demo.jnl
@@ -132,8 +132,10 @@ PAUSE
 
 PAUSE
 !      *********************************************************
-use "http://eosdap.hdfgroup.org:8080/opendap/data/NASAFILES/hdf5/GSSTF.2b.2008.01.01.he5"
-show data/att 3
+! This datasetor URL is not currently active. 
+!!  use "http://eosdap.hdfgroup.org:8080/opendap/data/NASAFILES/hdf5/GSSTF.2b.2008.01.01.he5"
+!! show data 3
+
 
 
 ! Let's look at the wind-stress vectors
@@ -155,24 +157,26 @@ go fland
 PAUSE
 !      *********************************************************
 
-
-use "http://satdat1.gso.uri.edu/opendap/Pathfinder/Northwest_Atlantic/6km/raw/1995/1/f95018175608.hdf"
-
-! Performance greatly enhanced through use of strides
-shade/levels=50 dsp_band_1[i=1:1024:4, j=1:1024:4]
-
-! We can see Florida and the Carribean islands, but they are upside down. 
-! Ferret can use the netCDF library to address this, with the /ORDER qualifier.
-cancel data 4
-use/order=x-y "http://satdat1.gso.uri.edu/opendap/Pathfinder/Northwest_Atlantic/6km/raw/1995/1/f95018175608.hdf"
-
-! The coordinate axes are just index values, but the longitude/latitude ranges are 
-! defined in global attributes. We can redefine the x and y axes to represent 
-! longitude and latitude axes.
-
-define axis/x=`..dsp_nav_earth_leflon`:`..dsp_nav_earth_ritlon`/npoints=1024/units=degrees_east `DSP_BAND_1,return=xaxis`
-define axis/y=`..dsp_nav_earth_botlat`:`..dsp_nav_earth_toplat`/npoints=1024/units=degrees_north `DSP_BAND_1,return=yaxis`
-shade/levels=v dsp_band_1[i=1:1024:4, j=1:1024:4]
-go fland 05
-
-set mode/last ignore
+! This datasetor URL is not currentlyactive. 
+!! use "http://satdat1.gso.uri.edu/opendap/Pathfinder/Northwest_Atlantic/6km/raw/1995/1/f95018175608.hdf"
+!!
+!!
+!!! Performance greatly enhanced through use of strides
+!!shade/levels=50 dsp_band_1[i=1:1024:4, j=1:1024:4]
+!!
+!!! We can see Florida and the Carribean islands, but they are upside down. 
+!!! Ferret can use the netCDF library to address this, with the /ORDER qualifier.
+!!cancel data 4
+!!use/order=x-y "http://satdat1.gso.uri.edu/opendap/Pathfinder/Northwest_Atlantic/6km/raw/1995/1/f95018175608.hdf"
+!!
+!!! The coordinate axes are just index values, but the longitude/latitude ranges are 
+!!! defined in global attributes. We can redefine the x and y axes to represent 
+!!! longitude and latitude axes.
+!!
+!!define axis/x=`..dsp_nav_earth_leflon`:`..dsp_nav_earth_ritlon`/npoints=1024/units=degrees_east `DSP_BAND_1,return=xaxis`
+!!define axis/y=`..dsp_nav_earth_botlat`:`..dsp_nav_earth_toplat`/npoints=1024/units=degrees_north `DSP_BAND_1,return=yaxis`
+!!shade/levels=v dsp_band_1[i=1:1024:4, j=1:1024:4]
+!!go fland 05
+!!
+!!set mode/last ignore
+!!

--- a/jnls/examples/land_detail_demo.jnl
+++ b/jnls/examples/land_detail_demo.jnl
@@ -1,3 +1,5 @@
+! land_detail_demo.jnl
+! Examples showing the lines drawn by the script land_detail.jnl
 
 SET WINDOW/SIZE=0.6
 CAN MODE logo
@@ -16,10 +18,22 @@ go land_detail black overlay 8 9 blue lightblue
 ! frame/file=land_detail_1.gif
 pause
 
-! Showing national boundaries and rivers. Access the detailed
-! topography/bathymetry data from Smith and Sandwell via OPeNDAP
+! Showing national boundaries and rivers. 
+! Access the detailed topography/bathymetry data in etopo5 if available
 
-use "http://ferret.pmel.noaa.gov/thredds/dodsC/data/PMEL/smith_sandwell_topo_v8_2.nc"
+CANCEL MODE verify
+SET MODE ignore
+SET REDIRECT/CLOBBER/FILE=error_file_demo.out STDERR
+CANCEL SYMBOL fer_last_error
+USE etopo5
+
+IF ($fer_last_error"0|*>1") THEN use etopo20
+CANCEL MODE ignore
+CANCEL REDIRECT
+sp rm error_file_demo.out
+SET MODE/LAST verify
+
+
 fill/lev=(0,10000,10000)/pal=tan/nokey/x=0:24/y=30:46 rose
 fill/over/nolab/lev=(-5000,-1000,500)(-1000,0,50)/key/pal=topo/x=0:24/y=30:46 rose
 go land_detail black overlay red green blue blue

--- a/jnls/examples/topo_palette_demo.jnl
+++ b/jnls/examples/topo_palette_demo.jnl
@@ -6,14 +6,28 @@
 ! Good levels for US elevation (in meters):
 ! (-6000,-1000,1000)(-1000,-100,100)(-100,100,10)(100,1000,100)(1000,6000,1000)
 
-use "http://ferret.pmel.noaa.gov/pmel/thredds/dodsC/data/PMEL/smith_sandwell_topo_v8_2.nc"
+ ! Access the detailed topography/bathymetry data in etopo5 if available
+
+CANCEL MODE verify
+SET MODE ignore
+SET REDIRECT/CLOBBER/FILE=error_file_demo.out STDERR
+CANCEL SYMBOL fer_last_error
+USE etopo5
+
+IF ($fer_last_error"0|*>1") THEN use etopo20
+CANCEL MODE ignore
+CANCEL REDIRECT
+sp rm error_file_demo.out
+SET MODE/LAST verify
+
+
 SET VAR/TITLE="Topography and Bathymetry" rose
 SET REGION/X=130E:160E/y=30S:0S
-shade/pal=topo/lev=(-9000,-1000,1000)(-1000,-100,100)(-100,100,10)(100,1000,100)(1000,4000,1000) rose
+FILL/PAL=topo/lev=(-9000,-1000,1000)(-1000,-100,100)(-100,100,10)(100,1000,100)(1000,4000,1000) rose
 
 ! A smaller region, choosing different levels, the colors
 ! used for each elevation are the same.
 SET REGION/X=134:144/Y=-18:-8
-SHADE/PAL=topo/LEV=(-2600,-100,50)(-100,100,5)(100,500,50) rose
+FILL/PAL=topo/LEV=(-2600,-100,50)(-100,100,5)(100,500,50) rose
 
-
+CANCEL DATA/ALL


### PR DESCRIPTION
Recent comments and questions e.g. issue 1990 shows that some of the demo journal files depend unnecessarily on datasets that reside on opendap servers.  For a demo, it's really best if the scripts are as self-contained as possible.  I've updated jnls/examples/topo_palette_demo.jnl and jnls/examples/land_detail_demo.jnl so they use datasets that should be installed with any installation of PyFerret or Ferret.

There are a few more demo journal files that use URL's.  A couple of them are demonstrating use of OPeNDAP data, so that's fine. I commented out some non-working URls in jns/examples/dods_demo.jnl. And I updated a reference to Patrick Brockmann, a colleague in France, just because I noticed and old address.

This isn't quite all of them - call_stack.jnl and call_stack_stick.jnl still have non-working url's - something to dig into another time.

