### PR TITLE
Fix format statement in getsym.F

### DIFF
--- a/ppl/symlib/getsym.F
+++ b/ppl/symlib/getsym.F
@@ -92,7 +92,7 @@ C
 
 	   CALL  DATE_AND_TIME(adate, atime, zone, ival)
 	   WRITE (label, 101) ival(5), ival(6), ival(7)
-  101	   FORMAT (I2.2, ':', I2.2 ':', I2.2)
+  101	   FORMAT (I2.2, ':', I2.2, ':', I2.2)
            NC = 8
 
 	ELSE IF(STR.EQ.'DATE')THEN


### PR DESCRIPTION
A missing comma caused pyferret to crash with error message:
```
At line 95 of file getsym.F
Fortran runtime error: Missing comma between descriptors
(I2.2, ':', I2.2 ':', I2.2)
```